### PR TITLE
Handle error codes from ppoll()

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -135,6 +135,11 @@ int READ_TO(int fd, char *whereto, size_t len, double to, bool *do_exit)
 			return 0;
 		}
 
+		if (fds[0].revents & (POLLERR|POLLHUP|POLLNVAL))
+		{
+			return -1;
+		}
+
 		if (fds[0].revents & POLLIN)
 		{
 			rc = read(fd, whereto, len);


### PR DESCRIPTION
- POLLERR, POLLHUP, POLLNVAL returned for terminated connections
- sudden client disconnect caused the server to spin at 100% cpu

See also https://github.com/flok99/entropybroker/issues/5