### PR TITLE
Add casts for crypto++ v6 compatibility

### DIFF
--- a/encrypt_stream_aes.cpp
+++ b/encrypt_stream_aes.cpp
@@ -39,7 +39,7 @@ bool encrypt_stream_aes::init(unsigned char *key_in, int key_len, unsigned char 
 #endif
 
 	unsigned char key_use[CryptoPP::AES::DEFAULT_KEYLENGTH] = { 0 };
-	memcpy(key_use, key_in, std::min(CryptoPP::AES::DEFAULT_KEYLENGTH, key_len));
+	memcpy(key_use, key_in, std::min((int)CryptoPP::AES::DEFAULT_KEYLENGTH, key_len));
 
 	if (enc)
 		delete enc;

--- a/encrypt_stream_camellia.cpp
+++ b/encrypt_stream_camellia.cpp
@@ -39,7 +39,7 @@ bool encrypt_stream_camellia::init(unsigned char *key_in, int key_len, unsigned 
 #endif
 
 	unsigned char temp_key[CryptoPP::Camellia::DEFAULT_KEYLENGTH] = { 0 };
-	memcpy(temp_key, key_in, std::min(CryptoPP::Camellia::DEFAULT_KEYLENGTH, key_len));
+	memcpy(temp_key, key_in, std::min((int)CryptoPP::Camellia::DEFAULT_KEYLENGTH, key_len));
 
 	if (enc)
 		delete enc;


### PR DESCRIPTION
In crypto++ commit 953252e44d25 ("Move from 'static' to 'enum' for class
constants") the macro CRYPTOPP_CONSTANT changed from adding a static
const int to the class to an enum, which does not take up space.

Therefore, definitions such as

    CRYPTOPP_CONSTANT(DEFAULT_KEYLENGTH = KeyBase::DEFAULT_KEYLENGTH)

now create DEFAULT_KEYLENGTH as an unnamed enum and not an int. The
result is that DEFAULT_KEYLENGTH is now no longer directly comparable
with ints, thanks to C++'s enum type conversion rules.

The fix is simple: cast to int, as was done in the crypto++ project in
the commit following the aforementioned: commit f5aa6f1f06b9 ("Cast
enums to int for comparison")

Closes: #8